### PR TITLE
Add support for default itemcost

### DIFF
--- a/src/TQVaultAE.DAL/Item.cs
+++ b/src/TQVaultAE.DAL/Item.cs
@@ -4483,7 +4483,11 @@ namespace TQVaultData
 			record = Database.DB.GetRecordFromFile(itemCostID);
 			if (record == null)
 			{
-				return;
+				record = Database.DB.GetRecordFromFile("records/game/itemcost.dbr");
+				if (record == null)
+				{
+					return;
+				}
 			}
 
 			if (TQDebug.ItemDebugLevel > 1)

--- a/src/TQVaultAE.GUI/Properties/AssemblyInfo.cs
+++ b/src/TQVaultAE.GUI/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("2.5.1.0")]
-[assembly: AssemblyFileVersion("2.5.1.0")]
+[assembly: AssemblyVersion("2.5.1.2")]
+[assembly: AssemblyFileVersion("2.5.1.2")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 
 // CLS compliant attribute


### PR DESCRIPTION
Some items in xpack2 doesn't have itemCostName or strengthRequirement defined,
in such cases the default itemcost equation is being used. This change adds the
support for the default itemcost record, as a fallback. Without this, str, int, dex requirement are not shown.
